### PR TITLE
Change dash for underscore in g-sorcery module name

### DIFF
--- a/layman/overlays/modules/g_sorcery/__init__.py
+++ b/layman/overlays/modules/g_sorcery/__init__.py
@@ -6,11 +6,11 @@ G-Sorcery plug-in module for layman.
 '''
 
 module_spec = {
-    'name': 'g-sorcery',
+    'name': 'g_sorcery',
     'description': __doc__,
     'provides':{
         'g-sorcery-module': {
-            'name': 'g-sorcery',
+            'name': 'g_sorcery',
             'class': 'GSorceryOverlay',
             'sourcefile': 'g_sorcery',
             'description': __doc__,


### PR DESCRIPTION
X-Gentoo-Bug: 582154
X-Gentoo-Bug-URL: https://bugs.gentoo.org/582154
